### PR TITLE
Fix for loading images with previously saved Address Book file.

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -81,7 +81,7 @@ public class ParserUtil {
      */
     public static Optional<Avatar> parseAvatar(Optional<String> avatar_image_path) throws IllegalValueException {
         // Return default Avatar image if empty
-        return avatar_image_path.isPresent() ? Optional.of(new Avatar(avatar_image_path.get())) : Optional.of(new Avatar());
+        return avatar_image_path.isPresent() ? Optional.of(new Avatar(Avatar.getDirectoryPath(avatar_image_path.get()))) : Optional.of(new Avatar());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Avatar.java
+++ b/src/main/java/seedu/address/model/person/Avatar.java
@@ -18,6 +18,10 @@ public class Avatar {
 
     public ObjectProperty<Image> avatarImage;
 
+    public static String getDirectoryPath(String imageFile) {
+        return AVATARS_DIRECTORY + imageFile;
+    }
+
     public Avatar() {
         // Default object -> 'generic' avatar
         this.avatarFilePath = DEFAULT_AVATAR_IMAGE_PATH;
@@ -26,7 +30,7 @@ public class Avatar {
     }
 
     public Avatar(String avatarFilePath) throws IllegalValueException {
-        this.avatarFilePath = AVATARS_DIRECTORY + avatarFilePath;
+        this.avatarFilePath = avatarFilePath;
         if(validFile(this.avatarFilePath)) {
             Image imgObj = new Image(this.avatarFilePath);
             this.avatarImage = new SimpleObjectProperty<Image>(imgObj);


### PR DESCRIPTION
Corrected bug in which image directory was appended twice to existing Person objects. App now loads correctly, as well as Avatar images, even when an existing `.xml` file is loaded.